### PR TITLE
lez: add lez-01 Hetzner host

### DIFF
--- a/ansible/inventory/dev
+++ b/ansible/inventory/dev
@@ -14,6 +14,7 @@ delivery-02.gc-us-central1-a.logos.dev ansible_host=34.123.201.25 data_center=gc
 delivery-db-01.ac-cn-hongkong-c.logos.dev ansible_host=47.242.86.169 data_center=ac-cn-hongkong-c dns_domain=status.im dns_entry=delivery-db-01.ac-cn-hongkong-c.logos.dev.status.im env=logos region=cn-hongkong-c stage=dev
 delivery-db-01.do-ams3.logos.dev ansible_host=209.38.53.240 data_center=do-ams3 dns_domain=status.im dns_entry=delivery-db-01.do-ams3.logos.dev.status.im env=logos region=ams3 stage=dev
 delivery-db-01.gc-us-central1-a.logos.dev ansible_host=136.115.120.136 data_center=gc-us-central1-a dns_entry=delivery-db-01.gc-us-central1-a.logos.dev.status.im env=logos region=us-central1-a stage=dev
+lez-01.he-eu-hel1.logos.dev ansible_host=65.108.237.32 data_center=he-eu-hel1 dns_domain=status.im dns_entry=lez-01.he-eu-hel1.logos.dev.status.im env=logos region=eu-hel1 stage=dev
 storage-01.ac-cn-hongkong-c.logos.dev ansible_host=47.238.229.111 data_center=ac-cn-hongkong-c dns_domain=status.im dns_entry=storage-01.ac-cn-hongkong-c.logos.dev.status.im env=logos region=cn-hongkong-c stage=dev
 storage-01.do-ams3.logos.dev ansible_host=24.144.78.200 data_center=do-ams3 dns_domain=status.im dns_entry=storage-01.do-ams3.logos.dev.status.im env=logos region=ams3 stage=dev
 storage-01.gc-us-central1-a.logos.dev ansible_host=34.42.230.59 data_center=gc-us-central1-a dns_entry=storage-01.gc-us-central1-a.logos.dev.status.im env=logos region=us-central1-a stage=dev
@@ -61,6 +62,12 @@ delivery-02.gc-us-central1-a.logos.dev
 delivery-db-01.gc-us-central1-a.logos.dev
 storage-01.gc-us-central1-a.logos.dev
 
+[he-eu-hel1]
+lez-01.he-eu-hel1.logos.dev
+
+[lez]
+lez-01.he-eu-hel1.logos.dev
+
 [logos.dev]
 blockchain-01.ac-cn-hongkong-c.logos.dev
 blockchain-01.do-ams3.logos.dev
@@ -75,6 +82,7 @@ delivery-02.gc-us-central1-a.logos.dev
 delivery-db-01.ac-cn-hongkong-c.logos.dev
 delivery-db-01.do-ams3.logos.dev
 delivery-db-01.gc-us-central1-a.logos.dev
+lez-01.he-eu-hel1.logos.dev
 storage-01.ac-cn-hongkong-c.logos.dev
 storage-01.do-ams3.logos.dev
 storage-01.gc-us-central1-a.logos.dev

--- a/hosts_lez.tf
+++ b/hosts_lez.tf
@@ -1,0 +1,16 @@
+/* Hetzner AX41-NVMe
+ * AMD Ryzen 5 3600
+ * 64 GB DDR4
+ * 2x 512 GB SSD NVMe */
+module "lez" {
+  source = "github.com/status-im/infra-tf-dummy-module"
+
+  name   = "lez"
+  group  = "lez"
+  env    = "logos"
+  stage  = terraform.workspace
+  region = "eu-hel1"
+  prefix = "he"
+
+  ips = local.ws["lez_node_ips"]
+}

--- a/workspaces.tf
+++ b/workspaces.tf
@@ -82,6 +82,8 @@ locals {
       node_db_gc_type = "e2-medium"           /* Google Cloud */
 
       node_db_data_vol_size = 100
+
+      lez_node_ips = []
     }
 
     dev = {
@@ -112,6 +114,10 @@ locals {
       gc_blockchain_count = 1
 
       do_chat_kc_count = 1
+
+      lez_node_ips = [
+        "65.108.237.32", # lez-01.he-eu-hel1.logos.dev
+      ]
     }
     test = {
       ac_node_count = 2


### PR DESCRIPTION
Renamed from `metal-01.he-eu-hel1.misc.lez` from `infra-misc`.

- [`infra-misc#c9d79e2a`](https://github.com/status-im/infra-misc/commit/c9d79e2a) - lez: move metal-01 host to infra-logos

Required for new LEZ Devnet setup in:
- https://github.com/status-im/infra-logos/issues/29