### PR TITLE
logos.dev: deploy Logos Chat KeyPackage cache

### DIFF
--- a/ansible/chat-kc.yml
+++ b/ansible/chat-kc.yml
@@ -1,0 +1,28 @@
+---
+- name: Verify Ansible versions
+  hosts: all
+  tags: always
+  become: false
+  run_once: true
+  gather_facts: false
+  tasks:
+    - local_action: command ./roles.py --check
+      changed_when: false
+
+- name: Configure Chat Store Nodes
+  serial: '{{ serial|default(1) }}'
+  hosts: chat-kc
+  pre_tasks:
+    - name: Enable Maintenance Mode
+      command: 'maintenance Ansible run by {{ lookup("env", "USER") }}'
+      tags: always
+  post_tasks:
+    - name: Disable Maintenance Mode
+      command: 'maintenance disable'
+      tags: always
+  roles:
+    - { role: infra-role-open-ports,   tags: open-ports }
+    - { role: infra-role-swap-file,    tags: swap-file  }
+    - { role: infra-role-certbot,      tags: certbot    }
+    - { role: chat-kc,                 tags: chat-kc    }
+    - { role: infra-role-nginx,        tags: nginx      }

--- a/ansible/group_vars/chat-kc.yml
+++ b/ansible/group_vars/chat-kc.yml
@@ -1,0 +1,36 @@
+---
+# Domain
+chat_kc_public_domain: 'devnet.chat-kc.logos.co'
+
+# Swap
+swap_file_size_mb: 2048
+
+# Certbot
+certbot_docker_enabled: true
+certbot_admin_email: 'devops@status.im'
+certbot_services_to_stop: ['nginx']
+certbot_certs:
+  - domains:
+      - '{{ chat_kc_public_domain }}'
+
+# Nginx
+nginx_http_params: '{{ nginx_http_default_params + ["limit_req_zone $binary_remote_addr zone=chat_kc:10m rate=10r/s"] }}'
+
+nginx_sites:
+  chat_kc_https:
+    - listen 443 ssl
+    - server_name {{ chat_kc_public_domain }}
+
+    - ssl_certificate     /etc/letsencrypt/live/{{ chat_kc_public_domain }}/fullchain.pem
+    - ssl_certificate_key /etc/letsencrypt/live/{{ chat_kc_public_domain }}/privkey.pem
+
+    - limit_req zone=chat_kc burst=20 nodelay
+
+    - location / {
+        proxy_pass http://localhost:{{ chat_kc_host_port }}/;
+      }
+
+# Firewall
+open_ports_list:
+  chat-kc:
+    - { port: [80, 443], comment: 'Chat KeyPackage Cache' }

--- a/ansible/roles/chat-kc/README.md
+++ b/ansible/roles/chat-kc/README.md
@@ -1,0 +1,61 @@
+# Description
+
+This role deploys [chat-store](https://github.com/logos-messaging/chat-store), an HTTP service that caches MLS KeyPackages for Logos Chat. Clients publish signed keypackages keyed by `device_id` (and device-list bundles keyed by `account_pub`) so contacts can be reached by ID without an out-of-band key exchange.
+
+The service is intentionally throwaway: it will be replaced by a λLEZ-based service in Logos Chat v0.3. It runs as a single Docker container (axum + rusqlite) behind an nginx reverse proxy with TLS.
+
+# Configuration
+
+The basic include:
+```yaml
+chat_kc_public_domain: 'devnet.chat-kc.logos.co'
+chat_kc_image_tag: 'deploy-logos-dev'
+```
+
+The container is built from the chat-store repo, pushed to Harbor, and pulled on the host. Retention and limits are passed as CLI flags to the binary:
+```yaml
+chat_kc_retention_days: 21       # drop bundles older than this
+chat_kc_max_per_identity: 100    # bundles retained per device_id
+chat_kc_prune_interval_secs: 3600
+```
+
+The SQLite database is stored on a persistent volume:
+```yaml
+chat_kc_data_dir: '/docker/chat-kc/data'   # mounted to /data in the container
+```
+
+# Ports
+
+* `8080` - HTTP API, bound to `127.0.0.1` (nginx proxies to it)
+* `443` - public HTTPS (nginx reverse proxy, Let's Encrypt cert)
+* `80` - certbot HTTP-01 challenge
+
+The container is never exposed directly; nginx terminates TLS for `chat_kc_public_domain` and proxies to the local container. A `limit_req` zone rate-limits requests per client IP.
+
+# Management
+
+The service runs via Docker Compose:
+```
+ $ docker ps | grep chat-kc
+chat-kc   harbor.status.im/logos-messaging/chat-store:deploy-logos-dev   Up 2 hours
+
+ $ docker logs chat-kc --tail 1
+INFO chat_store: chat-store listening on 0.0.0.0:8080
+```
+
+Check the API (returns 404 for an unknown device, which means the service is live):
+```
+ $ curl -s https://devnet.chat-kc.logos.co/v0/keypackage/deadbeef
+{"error":"no keypackage for device"}
+```
+
+The image is updated by Watchtower when a new tag is pushed to Harbor.
+
+# API
+
+* `POST /v0/keypackage` - publish a signed keypackage bundle for a `device_id`
+* `GET /v0/keypackage/{device_id}` — fetch the latest bundle, or 404
+* `POST /v0/account` - upsert the device-list bundle for an `account_pub`
+* `GET /v0/account/{account_pub}` — fetch the stored bundle, or 404
+
+The server verifies the Ed25519 signature over the payload before storing; it never decodes the payload itself. Consumers must re-verify on retrieve. See the [chat-store README](https://github.com/logos-messaging/chat-store) for the trust model.

--- a/ansible/roles/chat-kc/defaults/main.yml
+++ b/ansible/roles/chat-kc/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# Paths
+chat_kc_base_dir: '/docker/chat-kc'
+chat_kc_src_dir: '{{ chat_kc_base_dir }}/src'
+chat_kc_data_dir: '{{ chat_kc_base_dir }}/data'
+
+# Image
+chat_kc_image_name: 'harbor.status.im/logos-messaging/chat-store'
+chat_kc_image_tag: 'deploy-logos-dev'
+
+# Container
+chat_kc_cont_name: 'chat-kc'
+chat_kc_host_port: 8080
+chat_kc_container_port: 8080
+
+# Service flags (chat-store CLI args)
+chat_kc_retention_days: 21
+chat_kc_max_per_identity: 100
+chat_kc_prune_interval_secs: 3600
+chat_kc_log_level: 'info'
+
+# Consul
+chat_kc_service_name: 'chat-kc'
+chat_kc_consul_tags: ['logos', 'chat', 'keypackage-cache']
+chat_kc_consul_check_disabled: false
+chat_kc_consul_check_interval: '30s'
+chat_kc_consul_check_timeout: '5s'
+chat_kc_consul_success_before_passing: 0
+chat_kc_consul_failures_before_warning: 1
+chat_kc_consul_failures_before_critical: 2

--- a/ansible/roles/chat-kc/handlers/main.yml
+++ b/ansible/roles/chat-kc/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart chat-kc
+  community.docker.docker_compose_v2:
+    project_src: '{{ chat_kc_base_dir }}'
+    state: present
+    recreate: always
+  listen: restart-chat-kc

--- a/ansible/roles/chat-kc/tasks/config.yml
+++ b/ansible/roles/chat-kc/tasks/config.yml
@@ -1,0 +1,26 @@
+---
+- name: Create chat-kc directories
+  file:
+    path: '{{ item }}'
+    state: directory
+    owner: dockremap
+    group: docker
+    mode: 0755
+  loop:
+    - '{{ chat_kc_base_dir }}'
+    - '{{ chat_kc_data_dir }}'
+
+- name: Template docker-compose.yml
+  template:
+    src: docker-compose.yml.j2
+    dest: '{{ chat_kc_base_dir }}/docker-compose.yml'
+    owner: dockremap
+    group: docker
+    mode: 0644
+  notify: restart-chat-kc
+
+- name: Deploy chat-kc container
+  community.docker.docker_compose_v2:
+    project_src: '{{ chat_kc_base_dir }}'
+    state: present
+    pull: always

--- a/ansible/roles/chat-kc/tasks/consul.yml
+++ b/ansible/roles/chat-kc/tasks/consul.yml
@@ -1,0 +1,20 @@
+---
+- name: Create Consul service definition
+  include_role: name=infra-role-consul-service
+  vars:
+    consul_config_name:                      '{{ chat_kc_service_name }}'
+    consul_default_check_disabled:           '{{ chat_kc_consul_check_disabled }}'
+    consul_default_check_interval:           '{{ chat_kc_consul_check_interval }}'
+    consul_default_check_timeout:            '{{ chat_kc_consul_check_timeout }}'
+    consul_default_success_before_passing:   '{{ chat_kc_consul_success_before_passing }}'
+    consul_default_failures_before_warning:  '{{ chat_kc_consul_failures_before_warning }}'
+    consul_default_failures_before_critical: '{{ chat_kc_consul_failures_before_critical }}'
+    consul_services:
+      - name: '{{ chat_kc_service_name }}'
+        tags: '{{ chat_kc_consul_tags }}'
+        port: '{{ chat_kc_host_port }}'
+        checks:
+          - id:   '{{ chat_kc_service_name }}-status'
+            name: 'Chat KeyPackage Cache Healthcheck'
+            type: 'tcp'
+            tcp:  'localhost:{{ chat_kc_host_port }}'

--- a/ansible/roles/chat-kc/tasks/main.yml
+++ b/ansible/roles/chat-kc/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: config.yml
+- import_tasks: consul.yml

--- a/ansible/roles/chat-kc/templates/docker-compose.yml.j2
+++ b/ansible/roles/chat-kc/templates/docker-compose.yml.j2
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  chat-kc:
+    image: "{{ chat_kc_image_name }}:{{ chat_kc_image_tag }}"
+    container_name: "{{ chat_kc_cont_name }}"
+    restart: unless-stopped
+    command:
+      - "--bind"
+      - "0.0.0.0:{{ chat_kc_container_port }}"
+      - "--db"
+      - "/data/chat-store.db"
+      - "--retention-days"
+      - "{{ chat_kc_retention_days }}"
+      - "--max-per-identity"
+      - "{{ chat_kc_max_per_identity }}"
+      - "--prune-interval-secs"
+      - "{{ chat_kc_prune_interval_secs }}"
+    environment:
+      - "RUST_LOG={{ chat_kc_log_level }}"
+    ports:
+      - "127.0.0.1:{{ chat_kc_host_port }}:{{ chat_kc_container_port }}"
+    volumes:
+      - "{{ chat_kc_data_dir }}:/data"
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'

--- a/chat_kc.tf
+++ b/chat_kc.tf
@@ -28,3 +28,11 @@ module "chat-kc" {
     "443", /* public https */
   ]
 }
+
+resource "cloudflare_record" "devnet_chat_kc" {
+  zone_id = lookup(local.zones, "logos.co")
+  name    = "devnet.chat-kc"
+  value   = module.chat-kc.public_ips[0]
+  type    = "A"
+  proxied = false
+}

--- a/main.tf
+++ b/main.tf
@@ -11,3 +11,18 @@ terraform {
     path      = "terraform/logos/"
   }
 }
+
+/* CF Zones ------------------------------------*/
+
+/* CloudFlare Zone IDs required for records */
+data "cloudflare_zones" "active" {
+  filter { status = "active" }
+}
+
+/* For easier access to zone ID by domain name */
+locals {
+  zones = {
+    for zone in data.cloudflare_zones.active.zones :
+    zone.name => zone.id
+  }
+}


### PR DESCRIPTION
Deploys chat-store (MLS keypackage cache) for Logos Chat testnet. Image built manually and pushed to Harbor (no CI for now).

https://github.com/status-im/infra-logos/issues/24