### PR TITLE
chat-kc: add logos-delivery support

### DIFF
--- a/ansible/group_vars/chat-kc.yml
+++ b/ansible/group_vars/chat-kc.yml
@@ -34,3 +34,5 @@ nginx_sites:
 open_ports_list:
   chat-kc:
     - { port: [80, 443], comment: 'Chat KeyPackage Cache' }
+    - { port: 60000, comment: 'logos-delivery p2p' }
+    - { port: 60000, comment: 'logos-delivery discovery', protocol: 'udp' }

--- a/ansible/group_vars/delivery.yml
+++ b/ansible/group_vars/delivery.yml
@@ -29,11 +29,7 @@ logos_node_delivery_num_shards_in_network: 8
 logos_node_delivery_dns4_domain_name: '{{ dns_entry }}'
 
 # Protocols
-logos_node_delivery_relay: true
-logos_node_delivery_store: true
-logos_node_delivery_filter: true
-logos_node_delivery_lightpush: true
-logos_node_delivery_mix: true
+logos_node_delivery_protocols_enabled: ['relay', 'store', 'filter', 'lightpush', 'mix']
 logos_node_delivery_discv5: true
 logos_node_delivery_kad_discovery: true
 

--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -33,11 +33,7 @@ logos_node_delivery_cluster_id: 2
 logos_node_delivery_num_shards_in_network: 8
 logos_node_delivery_dns4_domain_name: '{{ dns_entry }}'
 
-logos_node_delivery_relay: true
-logos_node_delivery_store: true
-logos_node_delivery_filter: true
-logos_node_delivery_lightpush: true
-logos_node_delivery_mix: true
+logos_node_delivery_protocols_enabled: ['relay', 'store', 'filter', 'lightpush', 'mix']
 logos_node_delivery_discv5: true
 logos_node_delivery_kad_discovery: true
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -30,7 +30,7 @@
 
 - name: infra-role-logos-node
   src: git@github.com:status-im/infra-role-logos-node.git
-  version: bf28b4e6acd5f8233447c91ef68e48fe975e4d27
+  version: d8b4135331027afc76c56f52b3a7ba8247e2849a
 
 - name: infra-role-wazuh-agent
   src: git@github.com:status-im/infra-role-wazuh-agent.git

--- a/ansible/roles/chat-kc/defaults/main.yml
+++ b/ansible/roles/chat-kc/defaults/main.yml
@@ -12,6 +12,8 @@ chat_kc_image_tag: 'deploy-logos-dev'
 chat_kc_cont_name: 'chat-kc'
 chat_kc_host_port: 8080
 chat_kc_container_port: 8080
+chat_kc_p2p_port: 60000
+chat_kc_delivery_preset: 'logos.dev'
 
 # Service flags (chat-store CLI args)
 chat_kc_retention_days: 21

--- a/ansible/roles/chat-kc/templates/docker-compose.yml.j2
+++ b/ansible/roles/chat-kc/templates/docker-compose.yml.j2
@@ -10,6 +10,10 @@ services:
       - "0.0.0.0:{{ chat_kc_container_port }}"
       - "--db"
       - "/data/chat-store.db"
+      - "--p2p-port"
+      - "{{ chat_kc_p2p_port }}"
+      - "--preset"
+      - "{{ chat_kc_delivery_preset }}"
       - "--retention-days"
       - "{{ chat_kc_retention_days }}"
       - "--max-per-identity"
@@ -20,6 +24,8 @@ services:
       - "RUST_LOG={{ chat_kc_log_level }}"
     ports:
       - "127.0.0.1:{{ chat_kc_host_port }}:{{ chat_kc_container_port }}"
+      - "{{ chat_kc_p2p_port }}:{{ chat_kc_p2p_port }}/tcp"
+      - "{{ chat_kc_p2p_port }}:{{ chat_kc_p2p_port }}/udp"
     volumes:
       - "{{ chat_kc_data_dir }}:/data"
     labels:

--- a/chat_kc.tf
+++ b/chat_kc.tf
@@ -26,6 +26,11 @@ module "chat-kc" {
   open_tcp_ports = [
     "80",  /* certbot */
     "443", /* public https */
+    "60000", /* logos-delivery p2p */
+  ]
+
+  open_udp_ports = [
+    "60000", /* logos-delivery discovery */
   ]
 }
 

--- a/workspaces.tf
+++ b/workspaces.tf
@@ -56,7 +56,7 @@ locals {
       do_chat_kc_count = 0
       gc_chat_kc_count = 0
 
-      chat_kc_do_type = "s-1vcpu-2gb"        /* DigitalOcean */
+      chat_kc_do_type = "s-2vcpu-4gb"        /* DigitalOcean */
       chat_kc_ac_type = "ecs.t5-lc1m2.large" /* Alibaba Cloud */
       chat_kc_gc_type = "e2-medium"          /* Google Cloud */
 


### PR DESCRIPTION
- resize host to s-2vcpu-4gb (delivery node + HTTP on 1vcpu was too tight)
- open ports

Refs logos-messaging/chat-store#7